### PR TITLE
fix setup go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.24"
+          go-version-file: "go.mod"
           cache: true
 
       - name: Download dependencies

--- a/renovate.json
+++ b/renovate.json
@@ -5,18 +5,5 @@
   ],
   "postUpdateOptions": [
     "gomodTidy"
-  ],
-  "packageRules": [
-    {
-      "groupName": "Go version and GitHub Actions",
-      "matchManagers": ["gomod", "github-actions"],
-      "matchDepNames": ["go", "actions/setup-go"]
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchDepNames": ["go"],
-      "matchDepTypes": ["golang"],
-      "rangeStrategy": "bump"
-    }
   ]
 }


### PR DESCRIPTION
- use go-version-file in actions/setup-go
-  no longer grouped go-update in renovate